### PR TITLE
pkp/pkp-lib#5048 Small adjustments to unsubscribe flow

### DIFF
--- a/classes/notification/PKPNotificationOperationManager.inc.php
+++ b/classes/notification/PKPNotificationOperationManager.inc.php
@@ -407,7 +407,7 @@ abstract class PKPNotificationOperationManager implements INotificationInfoProvi
 
 				$mail->setBody($body);
 			}
-			
+
 			$mail->assignParams($emailParams);
 
 			$mail->addRecipient($user->getEmail(), $user->getFullName());
@@ -478,7 +478,7 @@ abstract class PKPNotificationOperationManager implements INotificationInfoProvi
 	 */
 	function getUnsubscribeNotificationUrl($request, $notification) {
 		$dispatcher = $request->getDispatcher();
-		$unsubscribeUrl = $dispatcher->url($request, ROUTE_PAGE, null, 'Notification', 'unsubscribeForm', null, array('validate' => $this->createUnsubscribeToken($notification), 'id' => $notification->getId()));
+		$unsubscribeUrl = $dispatcher->url($request, ROUTE_PAGE, null, 'notification', 'unsubscribe', null, array('validate' => $this->createUnsubscribeToken($notification), 'id' => $notification->getId()));
 
 		return $unsubscribeUrl;
 	}

--- a/classes/notification/form/PKPNotificationsUnsubscribeForm.inc.php
+++ b/classes/notification/form/PKPNotificationsUnsubscribeForm.inc.php
@@ -20,7 +20,7 @@
 import('lib.pkp.classes.form.Form');
 
 class PKPNotificationsUnsubscribeForm extends Form {
-	var $_notification; 
+	var $_notification;
 	var $_validationToken;
 
 	/**
@@ -77,12 +77,12 @@ class PKPNotificationsUnsubscribeForm extends Form {
 
 		$templateMgr->assign(array(
 			'contextName' => $context->getLocalizedName(),
-			'username' => $user->getUsername(),
+			'userEmail' => $user->getEmail(),
 			'emailSettings' => $emailSettings,
 			'validationToken' => $this->_validationToken,
 			'notificationId' => $this->_notification->getId(),
 		));
-		
+
 		return parent::fetch($request, $template, $display);
 	}
 

--- a/locale/en_US/common.po
+++ b/locale/en_US/common.po
@@ -1693,14 +1693,23 @@ msgstr "Navigation menu was succesfully updated"
 msgid "notification.removedNavigationMenu"
 msgstr "Navigation menu was succesfully removed"
 
+msgid "notification.unsubscribeNotifications.success"
+msgstr "You have been unsubscribed"
+
+msgid "notification.unsubscribeNotifications.error"
+msgstr "We could not unsubscribe you"
+
 msgid "notification.unsubscribeNotifications.pageMessage"
-msgstr "User: <b>{$username}</b>. Select the types of email notifications that you want to unsubscribed from. ({$contextName}). <br /> Notification settings are accessible at {$profileNotificationUrl}."
+msgstr "Select the emails that you no longer wish to receive at {$email} from {$contextName}."
+
+msgid "notification.unsubscribeNotifications.resubscribe"
+msgstr "You can resubscribe to email notifications at any time from your <a href='{$profileNotificationUrl}'>user profile</a>."
 
 msgid "notification.unsubscribeNotifications.successMessage"
-msgstr "The user <b>{$username}</b> has successfully unsubscribed from the selected email notifications. ({$contextName}). <br /> Notification settings are accessible at {$profileNotificationUrl}."
+msgstr "The email address {$email} has been successfully unsubscribed. We'll no longer send you those emails. You can resubscribe to email notifications at any time from your <a href='{$profileNotificationUrl}'>user profile</a>."
 
 msgid "notification.unsubscribeNotifications.errorMessage"
-msgstr "The user <b>{$username}</b> could not unsubscribed from the selected email notifications. ({$contextName}). <br /> Notification settings are accessible at {$profileNotificationUrl}."
+msgstr "There was an unexpected error and we could not unsubscribe the email address {$email}. You can unsubscribe from all email notifications in your <a href='{$profileNotificationUrl}'>user profile</a> or contact us directly for help."
 
 msgid "notification.unsubscribeNotifications"
 msgstr "Unsubscribe"

--- a/pages/notification/NotificationHandler.inc.php
+++ b/pages/notification/NotificationHandler.inc.php
@@ -69,23 +69,6 @@ class NotificationHandler extends Handler {
 	}
 
 	/**
-	 * Notification Unsubscribe Form
-	 * @param $args array
-	 * @param $request Request
-	 */
-	function unsubscribeForm($args, $request) {
-		$validationToken = $request->getUserVar('validate');
-		$notificationId = $request->getUserVar('id');
-
-		$notification = $this->_validateUnsubscribeRequest($validationToken, $notificationId);
-
-		import('lib.pkp.classes.notification.form.PKPNotificationsUnsubscribeForm');
-
-		$notificationsUnsubscribeForm = new PKPNotificationsUnsubscribeForm($notification, $validationToken);
-		$notificationsUnsubscribeForm->display();
-	}
-
-	/**
 	 * Notification Unsubscribe handler
 	 * @param $args array
 	 * @param $request Request
@@ -96,6 +79,21 @@ class NotificationHandler extends Handler {
 
 		$notification = $this->_validateUnsubscribeRequest($validationToken, $notificationId);
 
+		// Show the form on a get request
+		if (!$request->isPost()) {
+			$validationToken = $request->getUserVar('validate');
+			$notificationId = $request->getUserVar('id');
+
+			$notification = $this->_validateUnsubscribeRequest($validationToken, $notificationId);
+
+			import('lib.pkp.classes.notification.form.PKPNotificationsUnsubscribeForm');
+
+			$notificationsUnsubscribeForm = new PKPNotificationsUnsubscribeForm($notification, $validationToken);
+			$notificationsUnsubscribeForm->display();
+			return;
+		}
+
+		// Otherwise process the result
 		$this->setupTemplate($request);
 
 		import('lib.pkp.classes.notification.form.PKPNotificationsUnsubscribeForm');
@@ -124,7 +122,7 @@ class NotificationHandler extends Handler {
 
 		$templateMgr->assign(array(
 			'contextName' => $context->getLocalizedName(),
-			'username' => $user->getUsername(),
+			'userEmail' => $user->getEmail(),
 			'unsubscribeResult' => $unsubscribeResult,
 		));
 
@@ -149,7 +147,7 @@ class NotificationHandler extends Handler {
 
 		if (!isset($notification) || $notification->getId() == null) {
 			$this->getDispatcher()->handle404();
-		} 
+		}
 
 		$notificationManager = new NotificationManager();
 

--- a/pages/notification/index.php
+++ b/pages/notification/index.php
@@ -16,11 +16,9 @@
  *
  */
 
-
 switch ($op) {
 	case 'fetchNotification':
 	case 'unsubscribe':
-	case 'unsubscribeForm':
 		define('HANDLER_CLASS', 'NotificationHandler');
 		import('lib.pkp.pages.notification.NotificationHandler');
 		break;

--- a/templates/notification/unsubscribeNotificationsForm.tpl
+++ b/templates/notification/unsubscribeNotificationsForm.tpl
@@ -11,26 +11,39 @@
 {include file="frontend/components/header.tpl" pageTitle="notification.unsubscribeNotifications"}
 
 <div class="page page_unsubscribe_notifications">
-	{capture assign="profileNotificationUrl"}<a href="{url page="user" op="profile"}">{translate key="notification.notifications"}</a>{/capture}
-	{translate key="notification.unsubscribeNotifications.pageMessage" profileNotificationUrl=$profileNotificationUrl contextName=$contextName username=$username}
+	<h1>{translate key="notification.unsubscribeNotifications"}</h1>
+
+	<p>{translate key="notification.unsubscribeNotifications.pageMessage" contextName=$contextName email=$userEmail}
+
+	<form class="cmp_form" id="unsubscribeNotificationForm" method="post" action="{url router=$smarty.const.ROUTE_PAGE page="notification" op="unsubscribe"}">
+		{csrf}
+
+		<input type="hidden" name="validate" value="{$validationToken|escape}" />
+		<input type="hidden" name="id" value="{$notificationId|escape}" />
+
+		<fieldset>
+			<div class="fields">
+				{foreach from=$emailSettings key=$emailKey item=$emailSetting}
+					<div>
+						<label for="{$emailSetting.emailSettingName|escape}">
+							<input id="{$emailSetting.emailSettingName|escape}" name="{$emailSetting.emailSettingName|escape}" type="checkbox" value="1" checked="checked">
+							{translate key=$emailSetting.settingKey title="common.title"|translate}
+						</label>
+					</div>
+				{/foreach}
+			</div>
+		</fieldset>
+
+		{capture assign="profileNotificationUrl"}{url page="user" op="profile"}{/capture}
+		<p>{translate key="notification.unsubscribeNotifications.resubscribe" profileNotificationUrl=$profileNotificationUrl}</p>
+
+		<div class="buttons">
+			<button class="submit" type="submit">
+				{translate key="notification.unsubscribeNotifications"}
+			</button>
+		</div>
+	</form>
+
 </div>
-
-<form class="pkp_form" id="unsubscribeNotificationForm" method="post" action="{url router=$smarty.const.ROUTE_PAGE page="notification" op="unsubscribe"}">
-	{csrf}
-
-	<input type="hidden" name="validate" value="{$validationToken|escape}" />
-	<input type="hidden" name="id" value="{$notificationId|escape}" />
-
-	{foreach from=$emailSettings key=$emailKey item=$emailSetting}
-		{assign var="emailSettingName" value=$emailSetting.emailSettingName}
-		{capture assign="settingKey"}{translate key=$emailSetting.settingKey title="common.title"|translate}{/capture}
-
-		{fbvFormSection title=$settingKey list=true translate=false}
-			{fbvElement type="checkbox" id=$emailSettingName checked=1 label="notification.email"}
-		{/fbvFormSection}
-	{/foreach}
-
-	{fbvFormButtons id="unsubscribeNotificationSave" hideCancel=true submitText="common.save"}
-</form>
 
 {include file="frontend/components/footer.tpl"}

--- a/templates/notification/unsubscribeNotificationsResult.tpl
+++ b/templates/notification/unsubscribeNotificationsResult.tpl
@@ -11,11 +11,13 @@
 {include file="frontend/components/header.tpl" pageTitle="notification.unsubscribeNotifications"}
 
 <div class="page page_unsubscribe_notifications">
-	{capture assign="profileNotificationUrl"}<a href="{url page="user" op="profile"}">{translate key="notification.notifications"}</a>{/capture}
+	{capture assign="profileNotificationUrl"}{url page="user" op="profile"}{/capture}
 	{if $unsubscribeResult}
-		{translate key="notification.unsubscribeNotifications.successMessage" profileNotificationUrl=$profileNotificationUrl contextName=$contextName username=$username}
+		<h1>{translate key="notification.unsubscribeNotifications.success"}</h1>
+		<p>{translate key="notification.unsubscribeNotifications.successMessage" profileNotificationUrl=$profileNotificationUrl email=$userEmail}</p>
 	{else}
-		{translate key="notification.unsubscribeNotifications.errorMessage" profileNotificationUrl=$profileNotificationUrl contextName=$contextName username=$username}
+		<h1>{translate key="notification.unsubscribeNotifications.error"}</h1>
+		<p>{translate key="notification.unsubscribeNotifications.errorMessage" profileNotificationUrl=$profileNotificationUrl email=$userEmail}</p>
 	{/if}
 </div>
 


### PR DESCRIPTION
- Fix error from uppercase in unsubscribe URL
- Use the /unsubscribe URL for the form and the result
- Adjust text and layout of the forms and result messages